### PR TITLE
ระบุเวอร์ชั่น cec

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -11,7 +11,7 @@
 		"Southclaws/samp-whirlpool",
 		"Southclaws/zcmd",
 		"Y-Less/sscanf",
-		"aktah/cec"
+		"aktah/cec:v2.3"
 	],
 	"local": true,
 	"runtime": {


### PR DESCRIPTION
บังคับให้โหลด Pawn.RakNet สำหรับ include cec ล่าสุด ไม่รู้ทำไมถ้าไม่ตั้งเวอร์ชั่นแล้วบางครั้งก็โหลดตัวเก่ามาทำให้ Pawn.RakNet ไม่ถูก Ensure มาด้วย